### PR TITLE
Add step method

### DIFF
--- a/crates/uplc/src/machine.rs
+++ b/crates/uplc/src/machine.rs
@@ -88,6 +88,18 @@ impl Machine {
         }
     }
 
+    pub fn step(&mut self, state: MachineState) -> Result<MachineState, Error> {
+        use MachineState::*;
+        let state = match state {
+            Compute(context, env, t) => self.compute(context, env, t)?,
+            Return(context, value) => self.return_compute(context, value)?,
+            Done(t) => {
+                return Ok(Done(t));
+            }
+        };
+        return Ok(state);
+    }
+
     fn compute(
         &mut self,
         context: Context,

--- a/crates/uplc/src/machine.rs
+++ b/crates/uplc/src/machine.rs
@@ -70,25 +70,20 @@ impl Machine {
 
     pub fn run(&mut self, term: Term<NamedDeBruijn>) -> Result<Term<NamedDeBruijn>, Error> {
         use MachineState::*;
-
-        let startup_budget = self.costs.machine_costs.get(StepKind::StartUp);
-
-        self.spend_budget(startup_budget)?;
-
-        let mut state = Compute(Context::NoFrame, Rc::new(vec![]), term);
-
+        let mut state = self.get_initial_machine_state(term)?;
         loop {
-            state = match state {
-                Compute(context, env, t) => self.compute(context, env, t)?,
-                Return(context, value) => self.return_compute(context, value)?,
+            state = self.step(state)?;
+            match state {
+                Compute(_, _, _) => (),
+                Return(_, _) => (),
                 Done(t) => {
                     return Ok(t);
                 }
-            };
+            }
         }
     }
 
-    pub fn step(&mut self, state: MachineState) -> Result<MachineState, Error> {
+    fn step(&mut self, state: MachineState) -> Result<MachineState, Error> {
         use MachineState::*;
         let state = match state {
             Compute(context, env, t) => self.compute(context, env, t)?,
@@ -98,6 +93,14 @@ impl Machine {
             }
         };
         return Ok(state);
+    }
+
+    fn get_initial_machine_state(&mut self, term: Term<NamedDeBruijn>) -> Result<MachineState, Error> {
+        let startup_budget = self.costs.machine_costs.get(StepKind::StartUp);
+
+        self.spend_budget(startup_budget)?;
+
+        return Ok(MachineState::Compute(Context::NoFrame, Rc::new(vec![]), term));
     }
 
     fn compute(


### PR DESCRIPTION
```
shaakeedbelizaire@shaakeeds-air uplc % cargo test
   Compiling uplc v1.0.24-alpha (/Users/shaakeedbelizaire/Documents/SundaeSwap Labs/aiken/crates/uplc)
    Finished test [unoptimized + debuginfo] target(s) in 1.80s
     Running unittests src/lib.rs (/Users/shaakeedbelizaire/Documents/SundaeSwap Labs/aiken/target/debug/deps/uplc-1ce57e5560c5614c)

running 91 tests
test flat::tests::flat_encode_integer ... ok
test flat::tests::flat_encode_list_list_integer ... ok
test flat::tests::flat_encode_pair_pair_integer_bool_integer ... ok
test machine::cost_model::tests::assert_default_cost_model_v1_mainnet_2023_02_23 ... ignored, confusing atm
test machine::cost_model::tests::assert_default_cost_model_v2_mainnet_2023_02_23 ... ignored, confusing atm
test flat::tests::uplc_parser_string_escape ... ok
test flat::tests::flat_decode_integer ... ok
test flat::tests::flat_decode_pair_pair_integer_bool_integer ... ok
test machine::runtime::tests::any_range ... ok
test machine::runtime::tests::compact_tag_mid_range ... ok
test machine::runtime::tests::compact_tag_range ... ok
test flat::tests::unflat_string_escape ... ok
test flat::tests::flat_decode_list_list_integer ... ok
test machine::runtime::tests::to_any_tag ... ok
test machine::runtime::tests::to_compact_tag ... ok
test machine::runtime::tests::to_compact_tag_mid ... ok
test machine::tests::add_big_ints ... ok
test machine::tests::case_constr_case_0 ... ok
test machine::tests::case_constr_case_1 ... ok
test machine::value::tests::integer_log2_oracle ... ok
test machine::value::tests::to_ex_mem_bigint ... ok
test machine::tests::divide_integer ... ok
test machine::tests::bls_g1_add_associative ... ok
test machine::tests::bls_g2_add_associative ... ok
test optimize::shrinker::tests::identity_reduce_0_occurrence ... ok
test optimize::shrinker::tests::builtin_force_reduce_list_builtins ... ok
test optimize::shrinker::tests::builtin_force_reduce_if_builtin ... ok
test optimize::shrinker::tests::curry_reducer_test_2 ... ok
test optimize::shrinker::tests::identity_reduce_no_inline ... ok
test optimize::shrinker::tests::builtin_force_reduce_pair_builtins ... ok
test optimize::shrinker::tests::curry_reducer_test_1 ... ok
test optimize::shrinker::tests::inline_reduce_0_occurrence ... ok
test optimize::shrinker::tests::identity_reduce_param ... ok
test optimize::shrinker::tests::lambda_reduce_builtin ... ok
test optimize::shrinker::tests::inline_reduce_delay_sha ... ok
test optimize::shrinker::tests::identity_reduce_no_inline_2 ... ok
test optimize::shrinker::tests::lambda_reduce_constant ... ok
test optimize::shrinker::tests::lambda_reduce_var ... ok
test optimize::shrinker::tests::identity_reduce_usage ... ok
test optimize::shrinker::tests::lambda_reduce_force_delay_error_lam ... ok
test optimize::shrinker::tests::wrap_data_reduce_un_i_data ... ok
test optimize::shrinker::tests::wrap_data_reduce_i_data ... ok
test parser::tests::parse_builtin_add_integer_curried ... ok
test parser::tests::parse_apply ... ok
test parser::tests::parse_builtin_add_integer ... ok
test parser::tests::parse_builtin_divide_integer ... ok
test parser::tests::parse_builtin_cons_bytestring ... ok
test parser::tests::parse_builtin_append_bytestring ... ok
test parser::tests::parse_builtin_equals_integer ... ok
test parser::tests::parse_builtin_index_bytestring ... ok
test parser::tests::parse_builtin_equals_bytestring ... ok
test parser::tests::parse_builtin_length_of_bytestring ... ok
test parser::tests::parse_builtin_less_than_equals_bytestring ... ok
test parser::tests::parse_builtin_less_than_equals_integer ... ok
test parser::tests::parse_builtin_mod_integer ... ok
test parser::tests::parse_builtin_less_than_bytestring ... ok
test parser::tests::parse_builtin_quotient_integer ... ok
test parser::tests::parse_builtin_multiply_integer ... ok
test parser::tests::parse_builtin_less_than_integer ... ok
test parser::tests::parse_builtin_remainder_integer ... ok
test parser::tests::parse_builtin_subtract_integer ... ok
test parser::tests::parse_builtin_slice_bytestring ... ok
test parser::tests::parse_error ... ok
test parser::tests::parse_delay_lambda ... ok
test parser::tests::parse_formatted ... ok
test parser::tests::parse_lambda ... ok
test parser::tests::parse_list_bytestrings ... ok
test parser::tests::parse_list_empty ... ok
test parser::tests::parse_list_bools ... ok
test parser::tests::parse_list_list_integers ... ok
test parser::tests::parse_list_mixed_types ... ok
test parser::tests::parse_list_singleton_unit ... ok
test parser::tests::parse_list_multiline ... ok
test parser::tests::parse_list_type_mismatch ... ok
test parser::tests::parse_pair_bool_pair_integer_bytestring ... ok
test parser::tests::parse_pair_string_list_integer ... ok
test pretty::tests::format_pair_bool_pair_integer_bytestring ... ok
test parser::tests::parse_pair_unit_unit ... ok
test parser::tests::parse_pair_multiline ... ok
test optimize::shrinker::tests::curry_reducer_test_3 ... ok
test tx::tests::eval_missing_redeemer ... ok
test tx::tests::eval_extraneous_redeemer ... ok
test tx::tests::test_eval_4 ... ok
test tx::tests::test_eval_6 ... ok
test tx::tests::test_eval_5 ... ok
test tx::tests::test_eval_3 ... ok
test tx::tests::test_eval_2 ... ok
test tx::tests::test_eval_0 ... ok
test tx::tests::test_eval_1 ... ok
test tx::tests::test_eval_8 ... ok
test tx::tests::test_eval_7 ... ok

test result: ok. 89 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.09s

     Running tests/conformance.rs (/Users/shaakeedbelizaire/Documents/SundaeSwap Labs/aiken/target/debug/deps/conformance-347eda87cf50826a)

running 1 test
test evaluation ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.26s

     Running tests/integ_tests.rs (/Users/shaakeedbelizaire/Documents/SundaeSwap Labs/aiken/target/debug/deps/integ_tests-6a9b10e2042a717e)

running 5 tests
test integer ... ok
test case_constr ... ok
test one_way_fibonacci ... ok
test fibonacci ... ok
test jpg ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s

     Running tests/pretty_tests.rs (/Users/shaakeedbelizaire/Documents/SundaeSwap Labs/aiken/target/debug/deps/pretty_tests-b1a75a84c7eb7050)

running 9 tests
test constant_deeply_nested_list ... ok
test constant_data_bytes ... ok
test constant_data_list ... ok
test constant_list_integer ... ok
test constant_data_map ... ok
test constant_data_constr ... ok
test constant_pair_bool_bytestring ... ok
test constant_data_int ... ok
test constant_pair_unit_string ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests uplc

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```